### PR TITLE
Use nextjs-google-adsense for Google AdSense

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "emoji-regex": "^10.4.0",
     "marked": "^11.1.0",
     "next": "^12.3.1",
+    "nextjs-google-adsense": "^1.0.0",
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-preset-env": "^9.3.0",
     "prop-types": "^15.8.1",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -7,6 +7,7 @@ import "./index.css"
 
 // next/script tag
 import Script from 'next/script';
+import { GoogleAdSense } from 'nextjs-google-adsense';
 
 
 function MyApp({ Component, pageProps }) {
@@ -20,17 +21,14 @@ function MyApp({ Component, pageProps }) {
       }, []);
     return (
         <>
-
+            
             
             <Head>
             <meta name="google-adsense-account" content="ca-pub-2735251147722172" />
                 <meta name="yandex-verification" content="2fbda7b2014931f2" />
             <meta name="msvalidate.01" content="38099E1AE93A9BC0C89D053978747CF1" />
         
-                <Script
-                    src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2735251147722172"
-                    crossOrigin="anonymous"
-                />
+                
                 <Script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha512-  q5Y1Nrn3HWnEuJ6ujV4T6bX6jww+JjIjzYjJFhF0R+  JGJQ1+  1QvGCnOM9dPxXmjW5f2sO6dJ7P9uYicKxi1ow==" crossOrigin="anonymous"></Script>
                 <Script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></Script>
                 <Script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js" integrity="sha384-IDwe1+LCz02ROU9k972gdyvl+AESN10+x7tBKgc9I5HFtuNz0wWnPclzo6p9vxnk" crossOrigin="anonymous"></Script>
@@ -56,6 +54,9 @@ function MyApp({ Component, pageProps }) {
                     `}
                 </Script>
             <Navbar />
+            <GoogleAdSense
+                    publisherId="pub-2735251147722172"
+                />
             <Component {...pageProps} />
         </>
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -630,6 +630,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@^2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
@@ -736,6 +741,13 @@ next@^12.3.1:
     "@next/swc-win32-arm64-msvc" "12.3.4"
     "@next/swc-win32-ia32-msvc" "12.3.4"
     "@next/swc-win32-x64-msvc" "12.3.4"
+
+nextjs-google-adsense@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nextjs-google-adsense/-/nextjs-google-adsense-1.0.0.tgz#211530203622adc321edcdac0d779d845c4541fc"
+  integrity sha512-gVqV9EH1JkDYT70M8AlqCTYq2DrmtJ8nL8xajXp+D5vK+U5PUwCJHi5XSuD9W0nFMBLYDWhVx452c8OcrI53/A==
+  optionalDependencies:
+    fsevents "^2.3.2"
 
 node-fetch@^2.6.7:
   version "2.7.0"


### PR DESCRIPTION
Integrate `nextjs-google-adsense` package to replace direct Google AdSense script tags.

* **package.json**
  - Add `nextjs-google-adsense` to dependencies.

* **pages/_app.js**
  - Import `GoogleAdSense` from `nextjs-google-adsense`.
  - Replace direct Google AdSense script tags with `GoogleAdSense` component.
  - Pass the Google AdSense client ID to the `GoogleAdSense` component.

* **yarn.lock**
  - Add `nextjs-google-adsense` package details.

