### PR TITLE
Remove extra h1 tags and add meta description to pdf-merger page

### DIFF
--- a/pages/case-changer.js
+++ b/pages/case-changer.js
@@ -115,9 +115,6 @@ function App() {
                     onClick={copyToClipboard}
                 >Copy</button>
                 <hr></hr>
-                <h1 style={{
-                    textAlign: "center",
-                }}>Case Changer: A Handy Tool for Text Manipulation</h1>
                 <h2>Introduction</h2>
                 <p>Text is one of the most common forms of communication in the digital world. Whether it is for social media, blogging, academic writing, programming, or any other purpose, text plays a vital role in conveying information and expressing ideas. However, text also comes with various challenges and limitations, such as formatting, spelling, grammar, readability, and more. To overcome these challenges and enhance the quality and efficiency of text creation and editing, one needs to use various tools and utilities that can assist in manipulating and transforming text according to the desired style and purpose.</p>
                 <p>One such tool is the Case Changer, a user-friendly online utility that can transform text into various case styles effortlessly. It is a part of the suite of tools offered by txtUtils, a website that aims to provide a comprehensive hub for various textual utilities and enhancements. In this essay, I will share my personal experience of using the Case Changer tool, and how it has helped me in dealing with different cases in texts.</p>

--- a/pages/extractor.js
+++ b/pages/extractor.js
@@ -88,7 +88,6 @@ function App() {
                 }}>Copy</button>
 
                 <hr></hr>
-                <h1>Email and URL Extractor: A Handy Tool for Text Manipulation</h1>
                 <h2>Introduction</h2>
                 <p>Text is one of the most common forms of communication in the digital world. Whether it is for social media, blogging, academic writing, programming, or any other purpose, text plays a vital role in conveying information and expressing ideas. However, text also comes with various challenges and limitations, such as formatting, spelling, grammar, readability, and more. To overcome these challenges and enhance the quality and efficiency of text creation and editing, one needs to use various tools and utilities that can assist in analyzing and transforming text according to the desired style and purpose.</p>
                 <p>One such tool is the Email and URL Extractor, a user-friendly online utility that can extract emails and URLs from any text effortlessly. It is a part of the suite of tools offered by txtUtils, a website that aims to provide a comprehensive hub for various textual utilities and enhancements. In this essay, I will share my personal experience of using the Email and URL Extractor tool, and how it has helped me in dealing with different texts.</p>

--- a/pages/text-splitter.js
+++ b/pages/text-splitter.js
@@ -108,7 +108,6 @@ function App() {
                     className='text-center'
                 />
                 {/* write about it in at least 1000 words */}
-                <h1>Text Splitter: A Handy Tool for Text Manipulation</h1>
                 <h2>Introduction</h2>
                 <p>Text is one of the most common forms of communication in the digital world. Whether it is for social media, blogging, academic writing, programming, or any other purpose, text plays a vital role in conveying information and expressing ideas. However, text also comes with various challenges and limitations, such as formatting, spelling, grammar, readability, and more. To overcome these challenges and enhance the quality and efficiency of text creation and editing, one needs to use various tools and utilities that can assist in analyzing and transforming text according to the desired style and purpose.</p>
                 <p>One such tool is the Text Splitter, a user-friendly online utility that can split text into smaller segments based on different delimiters effortlessly. It is a part of the suite of tools offered by txtUtils, a website that aims to provide a comprehensive hub for various textual utilities and enhancements. In this essay, I will share my personal experience of using the Text Splitter tool, and how it has helped me in dealing with different texts.</p>

--- a/pages/tts.js
+++ b/pages/tts.js
@@ -99,7 +99,6 @@ export default function TextToSpeech() {
                 <button className='btn btn-primary' onClick={speakText}>Speak</button>
                 <button className='btn btn-danger' id={'toogle'} onClick={toogle_play_pause}>Stop</button>
 
-                <h1>Text to Speech: A Handy Tool for Text Conversion</h1>
                 <h2>Introduction</h2>
                 <p>Text is one of the most common forms of communication in the digital world. Whether it is for social media, blogging, academic writing, programming, or any other purpose, text plays a vital role in conveying information and expressing ideas. However, text also comes with various challenges and limitations, such as formatting, spelling, grammar, readability, and more. To overcome these challenges and enhance the quality and efficiency of text creation and editing, one needs to use various tools and utilities that can assist in analyzing and transforming text according to the desired style and purpose.</p>
                 <p>One such tool is the Text to Speech tool, a user-friendly online utility that can convert text into speech effortlessly. It is a part of the suite of tools offered by txtUtils, a website that aims to provide a comprehensive hub for various textual utilities and enhancements. In this essay, I will share my personal experience of using the Text to Speech tool, and how it has helped me in dealing with different texts.</p>


### PR DESCRIPTION
Remove extra `h1` tags from the specified pages.

* **pages/text-splitter.js**
  - Remove the extra `h1` tag with the text "Text Splitter: A Handy Tool for Text Manipulation".

* **pages/extractor.js**
  - Remove the extra `h1` tag with the text "Email and URL Extractor: A Handy Tool for Text Manipulation".

* **pages/tts.js**
  - Remove the extra `h1` tag with the text "Text to Speech: A Handy Tool for Text Conversion".

* **pages/case-changer.js**
  - Remove the extra `h1` tag with the text "Case Changer: A Handy Tool for Text Manipulation".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/codewithpom/TextUtils/pull/26?shareId=7d5cb8aa-40eb-4394-8b0c-df3be3906b2d).